### PR TITLE
Simplify API, clarify documentation, reduce repetition

### DIFF
--- a/examples/dcgan/dcgan_fuzzer.py
+++ b/examples/dcgan/dcgan_fuzzer.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 from lib.fuzz_utils import build_fetch_function
-from lib.coverage_functions import raw_logit_coverage_function
+from lib.coverage_functions import raw_coverage_function
 from lib.fuzzer import Fuzzer
 from lib.mutation_functions import do_basic_mutations
 from lib.sample_functions import uniform_sample_function
@@ -95,7 +95,7 @@ def main(_):
             input_tensors=[targets_tensor],
             coverage_tensors=[coverage_tensor],
             metadata_tensors=[loss_batch_tensor, grads_tensor],
-            coverage_function=raw_logit_coverage_function,
+            coverage_function=raw_coverage_function,
             metadata_function=metadata_function,
             objective_function=objective_function,
             mutation_function=mutation_function,

--- a/examples/nans/nan_fuzzer.py
+++ b/examples/nans/nan_fuzzer.py
@@ -20,7 +20,7 @@ import random
 import numpy as np
 import tensorflow as tf
 from lib import fuzz_utils
-from lib.coverage_functions import all_logit_coverage_function
+from lib.coverage_functions import sum_coverage_function
 from lib.fuzzer import Fuzzer
 from lib.mutation_functions import do_basic_mutations
 from lib.sample_functions import recent_sample_function
@@ -106,7 +106,7 @@ def main(_):
             input_tensors=input_tensors,
             coverage_tensors=coverage_tensors,
             metadata_tensors=metadata_tensors,
-            coverage_function=all_logit_coverage_function,
+            coverage_function=sum_coverage_function,
             metadata_function=metadata_function,
             objective_function=objective_function,
             mutation_function=mutation_function,

--- a/examples/quantize/README.md
+++ b/examples/quantize/README.md
@@ -6,11 +6,11 @@ casts those variables to use 16 bits.
 To train this model, execute something like this:
 
 ```
-python examples/quantize/quantized_model.py --checkpoint_dir='/tmp/quantized_checkpoints_2' --training_steps=10000
+python examples/quantize/quantized_model.py --checkpoint_dir='/tmp/quantized_checkpoints' --training_steps=10000
 ```
 
 To fuzz the trained model, execute something like this:
 
 ```
-python examples/quantize/quantized_fuzzer.py --checkpoint_dir=/tmp/quantized_checkpoints_2 --total_inputs_to_fuzz=1000000 --mutations_per_corpus_item=100 --alsologtostderr --output_path=/cns/ok-d/home/augustusodena/fuzzer/plots/quantized_image.png --ann_threshold=1.0 --perturbation_constraint=1.0 --strategy=ann
+python examples/quantize/quantized_fuzzer.py --checkpoint_dir=/tmp/quantized_checkpoints --total_inputs_to_fuzz=1000000 --mutations_per_corpus_item=100 --alsologtostderr --output_path=/cns/ok-d/home/augustusodena/fuzzer/plots/quantized_image.png --ann_threshold=1.0 --perturbation_constraint=1.0 --strategy=ann
 ```

--- a/examples/quantize/quantized_fuzzer.py
+++ b/examples/quantize/quantized_fuzzer.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 from lib import fuzz_utils
-from lib.coverage_functions import all_logit_coverage_function
+from lib.coverage_functions import sum_coverage_function
 from lib.fuzzer import Fuzzer
 from lib.mutation_functions import do_basic_mutations
 from lib.sample_functions import recent_sample_function
@@ -119,7 +119,7 @@ def main(_):
             input_tensors=input_tensors,
             coverage_tensors=coverage_tensors,
             metadata_tensors=metadata_tensors,
-            coverage_function=all_logit_coverage_function,
+            coverage_function=sum_coverage_function,
             metadata_function=metadata_function,
             objective_function=objective_function,
             mutation_function=mutation_function,

--- a/examples/quantize/quantized_fuzzer.py
+++ b/examples/quantize/quantized_fuzzer.py
@@ -19,9 +19,7 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 from lib import fuzz_utils
-from lib.corpus import InputCorpus
-from lib.corpus import seed_corpus_from_numpy_arrays
-from lib.coverage_functions import raw_logit_coverage_function
+from lib.coverage_functions import all_logit_coverage_function
 from lib.fuzzer import Fuzzer
 from lib.mutation_functions import do_basic_mutations
 from lib.sample_functions import recent_sample_function
@@ -53,20 +51,27 @@ tf.flags.DEFINE_boolean(
 FLAGS = tf.flags.FLAGS
 
 
+if FLAGS.checkpoint_dir is None:
+    raise ValueError('checkpoint_dir flag must be specified')
+
+
+
 def metadata_function(metadata_batches):
-    """Gets the metadata."""
+    """Gets the metadata, for computing the objective function."""
     logit_32_batch = metadata_batches[0]
     logit_16_batch = metadata_batches[1]
     metadata_list = []
     for idx in range(logit_16_batch.shape[0]):
-        metadata_list.append((logit_32_batch[idx], logit_16_batch[idx]))
+        metadata_list.append({
+            "logits_32": logit_32_batch[idx],
+            "logits_16": logit_16_batch[idx]})
     return metadata_list
 
 
 def objective_function(corpus_element):
     """Checks if the element is misclassified."""
-    logits_32 = corpus_element.metadata[0]
-    logits_16 = corpus_element.metadata[1]
+    logits_32 = corpus_element.metadata["logits_32"]
+    logits_16 = corpus_element.metadata["logits_16"]
     prediction_16 = np.argmax(logits_16)
     prediction_32 = np.argmax(logits_32)
     if prediction_16 == prediction_32:
@@ -80,6 +85,12 @@ def objective_function(corpus_element):
     return True
 
 
+def mutation_function(elt):
+    """Mutates the element in question."""
+    return do_basic_mutations(
+        elt, FLAGS.mutations_per_corpus_item, FLAGS.perturbation_constraint)
+
+
 # pylint: disable=too-many-locals
 def main(_):
     """Constructs the fuzzer and fuzzes."""
@@ -87,49 +98,43 @@ def main(_):
     # Log more
     tf.logging.set_verbosity(tf.logging.INFO)
 
-    coverage_function = raw_logit_coverage_function
+    # Set up initial seed inputs
     image, label = fuzz_utils.basic_mnist_input_corpus(
         choose_randomly=FLAGS.random_seed_corpus
     )
-    numpy_arrays = [[image, label]]
+    seed_inputs = [[image, label]]
     image_copy = image[:]
 
     with tf.Session() as sess:
+        # Specify input, coverage, and metadata tensors
+        input_tensors, coverage_tensors, metadata_tensors = \
+          fuzz_utils.get_tensors_from_checkpoint(
+              sess, FLAGS.checkpoint_dir
+          )
 
-        tensor_map = fuzz_utils.get_tensors_from_checkpoint(
-            sess, FLAGS.checkpoint_dir
-        )
-
-        fetch_function = fuzz_utils.build_fetch_function(sess, tensor_map)
-
-        size = FLAGS.mutations_per_corpus_item
-
-        def mutation_function(elt):
-            """Mutates the element in question."""
-            return do_basic_mutations(elt, size, FLAGS.perturbation_constraint)
-
-        seed_corpus = seed_corpus_from_numpy_arrays(
-            numpy_arrays, coverage_function, metadata_function, fetch_function
-        )
-        corpus = InputCorpus(
-            seed_corpus, recent_sample_function, FLAGS.ann_threshold, "kdtree"
-        )
+        # Construct and run fuzzer
         fuzzer = Fuzzer(
-            corpus,
-            coverage_function,
-            metadata_function,
-            objective_function,
-            mutation_function,
-            fetch_function,
+            sess=sess,
+            seed_inputs=seed_inputs,
+            input_tensors=input_tensors,
+            coverage_tensors=coverage_tensors,
+            metadata_tensors=metadata_tensors,
+            coverage_function=all_logit_coverage_function,
+            metadata_function=metadata_function,
+            objective_function=objective_function,
+            mutation_function=mutation_function,
+            sample_function=recent_sample_function,
+            threshold=FLAGS.ann_threshold,
         )
         result = fuzzer.loop(FLAGS.total_inputs_to_fuzz)
+
         if result is not None:
             # Double check that there is persistent disagreement
             for idx in range(10):
                 logits, quantized_logits = sess.run(
-                    [tensor_map["coverage"][0], tensor_map["coverage"][1]],
+                    [coverage_tensors[0], coverage_tensors[1]],
                     feed_dict={
-                        tensor_map["input"][0]: np.expand_dims(
+                        input_tensors[0]: np.expand_dims(
                             result.data[0], 0
                         )
                     },

--- a/examples/quantize/quantized_model.py
+++ b/examples/quantize/quantized_model.py
@@ -24,7 +24,7 @@ import tensorflow as tf
 
 tf.flags.DEFINE_string(
     "checkpoint_dir",
-    "/tmp/nanfuzzer",
+    "/tmp/quantizefuzzer",
     "The overall dir in which we store experiments",
 )
 tf.flags.DEFINE_string(

--- a/examples/tfgrad/cumprod.py
+++ b/examples/tfgrad/cumprod.py
@@ -1,0 +1,116 @@
+# Copyright 2018 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fuzz a tf op to get a NaN."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import random
+import numpy as np
+import tensorflow as tf
+from lib import fuzz_utils
+from lib.coverage_functions import raw_coverage_function
+from lib.fuzzer import Fuzzer
+from lib.mutation_functions import do_basic_mutations
+from lib.sample_functions import recent_sample_function
+
+tf.flags.DEFINE_integer(
+    "total_inputs_to_fuzz", 100, "Loops over the whole corpus."
+)
+tf.flags.DEFINE_integer(
+    "mutations_per_corpus_item", 100, "Number of times to mutate corpus item."
+)
+tf.flags.DEFINE_float(
+    "ann_threshold",
+    1.0,
+    "Distance below which we consider something new coverage.",
+)
+tf.flags.DEFINE_integer("seed", None, "Random seed for both python and numpy.")
+tf.flags.DEFINE_boolean(
+    "random_seed_corpus", False, "Whether to choose a random seed corpus."
+)
+FLAGS = tf.flags.FLAGS
+
+
+def metadata_function(metadata_batches):
+    """Gets the metadata."""
+    metadata_list = [metadata_batches[0][i] for i in range(len(metadata_batches[0]))]
+    return metadata_list
+
+
+def objective_function(corpus_element):
+    """Checks if the metadata is inf or NaN."""
+    metadata = corpus_element.metadata
+    if all([np.isfinite(d).all() for d in metadata]):
+        return False
+
+    tf.logging.info("Objective function satisfied: non-finite element found.")
+    return True
+
+
+def mutation_function(elt):
+    """Mutates the element in question."""
+    return do_basic_mutations(
+        elt, FLAGS.mutations_per_corpus_item)
+
+
+def main(_):
+    """Constructs the fuzzer and performs fuzzing."""
+
+    # Log more
+    tf.logging.set_verbosity(tf.logging.INFO)
+    # Set the seeds!
+    if FLAGS.seed:
+        random.seed(FLAGS.seed)
+        np.random.seed(FLAGS.seed)
+
+    # Set up seed inputs
+    sz = 16
+    target_seed = np.random.uniform(low=0.0, high=1.0, size=(sz,))
+    seed_inputs = [[target_seed]]
+
+    # Specify input, coverage, and metadata tensors
+    input_tensor = tf.placeholder(tf.int32, [None, sz])
+    op_tensor = tf.cumprod(input_tensor)
+    grad_tensors = tf.gradients(op_tensor, input_tensor)
+
+    with tf.Session() as sess:
+        # Construct and run fuzzer
+        fuzzer = Fuzzer(
+            sess=sess,
+            seed_inputs=seed_inputs,
+            input_tensors=[input_tensor],
+            coverage_tensors=[input_tensor],
+            metadata_tensors=grad_tensors,
+            coverage_function=raw_coverage_function,
+            metadata_function=metadata_function,
+            objective_function=objective_function,
+            mutation_function=mutation_function,
+            sample_function=recent_sample_function,
+            threshold=FLAGS.ann_threshold,
+        )
+
+        result = fuzzer.loop(FLAGS.total_inputs_to_fuzz)
+        if result is not None:
+            tf.logging.info("Fuzzing succeeded.")
+            tf.logging.info(
+                "Generations to make satisfying element: %s.",
+                result.oldest_ancestor()[1],
+            )
+        else:
+            tf.logging.info("Fuzzing failed to satisfy objective function.")
+
+
+if __name__ == "__main__":
+    tf.app.run()

--- a/examples/tfgrad/cumprod.py
+++ b/examples/tfgrad/cumprod.py
@@ -92,7 +92,7 @@ def main(_):
             sess=sess,
             seed_inputs=seed_inputs,
             input_tensors=[input_tensor],
-            coverage_tensors=[input_tensor],
+            coverage_tensors=grad_tensors,
             metadata_tensors=grad_tensors,
             coverage_function=raw_coverage_function,
             metadata_function=metadata_function,

--- a/examples/tfgrad/cumprod.py
+++ b/examples/tfgrad/cumprod.py
@@ -62,7 +62,7 @@ def objective_function(corpus_element):
 def mutation_function(elt):
     """Mutates the element in question."""
     return do_basic_mutations(
-        elt, FLAGS.mutations_per_corpus_item)
+        elt, FLAGS.mutations_per_corpus_item, a_min=None, a_max=None)
 
 
 def main(_):
@@ -77,7 +77,8 @@ def main(_):
 
     # Set up seed inputs
     sz = 16
-    target_seed = np.random.uniform(low=0.0, high=1.0, size=(sz,))
+#    target_seed = np.random.uniform(low=0.0, high=1.0, size=(sz,))
+    target_seed = np.ones(sz, dtype=np.uint32)*4
     seed_inputs = [[target_seed]]
 
     # Specify input, coverage, and metadata tensors

--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -33,7 +33,7 @@ class CorpusElement(object):
 
         Args:
           data: a list of numpy arrays representing the mutated data.
-          metadata: arbitrary python object to be used by the fuzzer for e.g.
+          metadata: arbitrary python object to be used by the fuzzer for
             computing the objective function during the fuzzing loop.
           coverage: an arbitrary hashable python object that guides fuzzing process.
           parent: a reference to the CorpusElement this element is a mutation of.
@@ -60,7 +60,9 @@ class CorpusElement(object):
 def seed_corpus_from_numpy_arrays(
     numpy_arrays, coverage_function, metadata_function, fetch_function
 ):
-    """Constructs a seed_corpus given numpy_arrays.
+    """Constructs a starting corpus, given numpy_arrays of inputs,
+    by passing them through the system to produce outputs (i.e. coverage
+    representations)
 
     We only use the first element of the batch that we fetch, because
     we're only trying to create one corpus element, and we may end up
@@ -69,8 +71,8 @@ def seed_corpus_from_numpy_arrays(
     Args:
       numpy_arrays: multiple lists of input_arrays, each list with as many
         arrays as there are input tensors.
-      coverage_function: a function that does CorpusElement -> Coverage.
-      metadata_function: a function that does CorpusElement -> Metadata.
+      coverage_function: a function that does coverage batches -> coverage object.
+      metadata_function: a function that does metadata batches -> metadata object.
       fetch_function: grabs output from tensorflow runtime.
     Returns:
       List of CorpusElements.

--- a/lib/coverage_functions.py
+++ b/lib/coverage_functions.py
@@ -19,17 +19,16 @@ from __future__ import print_function
 import numpy as np
 
 
-def all_logit_coverage_function(coverage_batches):
-    """Computes coverage based on the sum of the absolute values of the logits.
+def sum_coverage_function(coverage_batches):
+    """Computes coverage as the sum of the absolute values of coverage_batches.
 
     Args:
         coverage_batches: Numpy arrays containing coverage information pulled from
-          a call to sess.run. In this case, we assume that these correspond to a
-          batch of logits.
+          a call to sess.run.
 
     Returns:
-        A python integer corresponding to the sum of the absolute values of the
-        logits.
+        A list of python integers corresponding to the sum of the absolute
+        values of the entries in coverage_batches.
     """
     coverage_batch = coverage_batches[0]
     coverage_list = []
@@ -40,18 +39,17 @@ def all_logit_coverage_function(coverage_batches):
     return coverage_list
 
 
-def raw_logit_coverage_function(coverage_batches):
-    """The coverage in this case is just the actual logits.
+def raw_coverage_function(coverage_batches):
+    """The coverage in this case is just the actual values of coverage_batches.
 
     This coverage function is intended for use with a nearest neighbor method.
 
     Args:
         coverage_batches: Numpy arrays containing coverage information pulled from
-          a call to sess.run. In this case, we assume that these correspond to a
-          batch of logits.
+          a call to sess.run.
 
     Returns:
-        A numpy array of logits.
+        A list of numpy arrays corresponding to the entries in coverage_batches.
     """
     # For our purpose, we only need the first coverage element
     coverage_batch = coverage_batches[0]

--- a/lib/fuzz_utils.py
+++ b/lib/fuzz_utils.py
@@ -150,12 +150,7 @@ def get_tensors_from_checkpoint(sess, checkpoint_dir):
     coverage_tensors = tf.get_collection("coverage_tensors")
     metadata_tensors = tf.get_collection("metadata_tensors")
 
-    tensor_map = {
-        "input": input_tensors,
-        "coverage": coverage_tensors,
-        "metadata": metadata_tensors,
-    }
-    return tensor_map
+    return input_tensors, coverage_tensors, metadata_tensors
 
 
 def fetch_function(
@@ -183,16 +178,16 @@ def fetch_function(
     return coverage_batches, metadata_batches
 
 
-def build_fetch_function(sess, tensor_map):
+def build_fetch_function(sess, input_tensors, coverage_tensors, metadata_tensors):
     """Constructs fetch function given session and tensors."""
 
     def func(input_batches):
         """The fetch function."""
         return fetch_function(
             sess,
-            tensor_map["input"],
-            tensor_map["coverage"],
-            tensor_map["metadata"],
+            input_tensors,
+            coverage_tensors,
+            metadata_tensors,
             input_batches,
         )
 

--- a/lib/fuzzer.py
+++ b/lib/fuzzer.py
@@ -116,6 +116,11 @@ class Fuzzer(object):
                     parent,
                 )
                 if self.objective_function(new_element):
+                    tf.logging.info(
+                        "OBJECTIVE SATISFIED: coverage: %s, metadata: %s",
+                        new_element.coverage,
+                        new_element.metadata,
+                    )
                     return new_element
                 self.corpus.maybe_add_to_corpus(new_element)
 

--- a/lib/mutation_functions.py
+++ b/lib/mutation_functions.py
@@ -32,6 +32,7 @@ def do_basic_mutations(
     mutations_count: Integer representing number of mutations to do in
       parallel.
     constraint: If not None, a constraint on the norm of the total mutation.
+    a_min, a_max: Constraints on the values of the mutated input
 
   Returns:
     A list of batches, the first of which is mutated images and the second of

--- a/lib/mutation_functions.py
+++ b/lib/mutation_functions.py
@@ -54,7 +54,7 @@ def do_basic_mutations(
         sigma = 0.2
         noise = np.random.normal(size=image_batch.shape, scale=sigma)
     elif np.issubdtype(image_batch.dtype, np.integer):
-        noise = np.random.randint(a_min, a_max+1)
+        noise = np.random.randint(-1, 2, size=image_batch.shape)
 
     if constraint is not None:
         # (image - original_image) is a single image. it gets broadcast into a batch
@@ -71,9 +71,10 @@ def do_basic_mutations(
     else:
         mutated_image_batch = noise + image_batch
 
-    mutated_image_batch = np.clip(
-        mutated_image_batch, a_min=a_min, a_max=a_max
-    )
+    if a_min is not None or a_max is not None:
+        mutated_image_batch = np.clip(
+            mutated_image_batch, a_min=a_min, a_max=a_max
+        )
 
     if len(corpus_element.data) > 1:
         label_batch = np.tile(label, [mutations_count])

--- a/lib/mutation_functions.py
+++ b/lib/mutation_functions.py
@@ -54,7 +54,8 @@ def do_basic_mutations(
         sigma = 0.2
         noise = np.random.normal(size=image_batch.shape, scale=sigma)
     elif np.issubdtype(image_batch.dtype, np.integer):
-        noise = np.random.randint(-1, 2, size=image_batch.shape)
+        sigma = 10
+        noise = np.round(np.random.normal(size=image_batch.shape, scale=sigma))
 
     if constraint is not None:
         # (image - original_image) is a single image. it gets broadcast into a batch

--- a/lib/mutation_functions.py
+++ b/lib/mutation_functions.py
@@ -46,10 +46,15 @@ def do_basic_mutations(
         image_batch = np.tile(image, [mutations_count, 1, 1, 1])
     else:
         image = corpus_element.data[0]
-        image_batch = np.tile(image, [mutations_count] + list(image.shape))
+        image_batch = np.tile(
+            image,
+            [mutations_count] + list(np.ones_like(image.shape)))
 
-    sigma = 0.2
-    noise = np.random.normal(size=image_batch.shape, scale=sigma)
+    if np.issubdtype(image_batch.dtype, np.floating):
+        sigma = 0.2
+        noise = np.random.normal(size=image_batch.shape, scale=sigma)
+    elif np.issubdtype(image_batch.dtype, np.integer):
+        noise = np.random.randint(a_min, a_max+1)
 
     if constraint is not None:
         # (image - original_image) is a single image. it gets broadcast into a batch


### PR DESCRIPTION
Simplify API: Hide the construction of fetch_function from the user
Clarify documentation, and make metadata in example a dict for clarity
Switch quantized_fuzzer example from raw to all logit, it seems faster
Reformat nan_fuzzer to use new Fuzzer API